### PR TITLE
docs: fix reference for the jobName in a matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ jobs:
       - uses: inception-health/otel-upload-test-artifact-action@latest
         if: always()
         with:
-          jobName: "lint-and-test"
-          stepName: "run tests (${{ matrix.os }})"
+          jobName: "lint-and-test (${{ matrix.os }})"
+          stepName: "run tests"
           path: "junit.xml"
           type: "junit"
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix the example since `jobName` is the one with the matrix values.

See https://github.com/v1v/otel-upload-test-artifact-action/blob/fc344a1ce206d702f748ae1418d0b426ae582c30/.github/workflows/code-quality-pr-check.yml#L46-L47